### PR TITLE
Throw helpful error if pdftk binary not installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -309,6 +309,17 @@ class PdfTk {
                 }
             });
 
+            child.on('error', (e) => {
+              if (e.code === 'ENOENT') {
+                throw new Error(`
+                  pdftk was called but is not installed on your system.
+                  Install it here: https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/
+                `);
+              } else {
+                throw e
+              }
+            });
+
             child.stdout.on('data', data => result.push(Buffer.from(data)));
 
             child.on('close', code => {


### PR DESCRIPTION
Previously a ENOENT exception was thrown, this is slightly more helpful. The tests don't seem to be passing for me, are they for you @jjwilly16 ?