### PR TITLE
Missing pdftk executable causes promise chain to hang

### DIFF
--- a/index.js
+++ b/index.js
@@ -300,12 +300,12 @@ class PdfTk {
 
             child.on('error', e => {
                 if (e.code === 'ENOENT') {
-                    throw new Error(`
+                    return reject(new Error(`
                     pdftk was called but is not installed on your system.
                     Install it here: https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/
-                    `);
+                    `));
                 } else {
-                    throw e;
+                    return reject(e);
                 }
             });
 


### PR DESCRIPTION
Throwing in the ChildProcess error event causes the output() promise
to never resolve. Call reject() with the error instead so that a
missing pdftk executable doesn't hang the promise chain.