### PR TITLE
Override temporary file write directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Name | Description | Type | Default Value
 bin | Path to your PdfTk executable | String | 'pdftk'
 Promise | Promise library to implement | Object | Promise
 ignoreWarnings | Ignore PdfTk warnings. Useful with huge PDF files | Boolean | False
+tempDir | changes the directory where temporary files are stored | String | libPath + './node-pdftk-tmp/')
 
 ## Configuring your PdfTk path ##
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ pdftk.configure({
     bin: '/your/path/to/pdftk/bin',
     Promise: require('bluebird'),
     ignoreWarnings: true,
+    tempDir: path.join(__dirname, './your/custom/temp/dir')
 });
 ```
 
@@ -97,7 +98,7 @@ Name | Description | Type | Default Value
 bin | Path to your PdfTk executable | String | 'pdftk'
 Promise | Promise library to implement | Object | Promise
 ignoreWarnings | Ignore PdfTk warnings. Useful with huge PDF files | Boolean | False
-tempDir | changes the directory where temporary files are stored | String | libPath + './node-pdftk-tmp/')
+tempDir | Changes the directory where temporary files are stored. MUST BE ABSOLUTE PATH. Use the [path](https://nodejs.org/docs/latest/api/path.html) module. | String | libPath + './node-pdftk-tmp/')
 
 ## Configuring your PdfTk path ##
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ class PdfTk {
              * @member
              * @type {String}
              */
-            this._tempDir = this._tempDir || './node-pdftk-tmp/';
+            this._tempDir = this._tempDir || path.join(__dirname,'./node-pdftk-tmp/');
 
             const input = [];
 

--- a/index.js
+++ b/index.js
@@ -308,7 +308,7 @@ class PdfTk {
      * @public
      * @param {String} writeFile - Path to the output file to write from stdout. If used with the "outputDest" parameter, two files will be written.
      * @param {String} [outputDest] - The output file to write without stdout. When present, the returning promise will not contain the output buffer. If used with the "writeFile" parameter, two files will be written.
-     * @param {Boolean} [needsOutput=true] - Optional boolean used to disclude the 'output' argument (only used for specific methods).
+     * @param {Boolean} [needsOutput=true] - Optional boolean used to exclude the 'output' argument (only used for specific methods).
      * @returns {Promise} Promise that resolves the output buffer, if "outputDest" is not given.
      */
     output(writeFile, outputDest, needsOutput = true) {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ class PdfTk {
              * @member
              * @type {String}
              */
-            this._tempDir = this._tempDir || path.join(__dirname,'./node-pdftk-tmp/');
+            this._tempDir = this._tempDir || path.join(__dirname, './node-pdftk-tmp/');
+
 
             const input = [];
 
@@ -65,9 +66,9 @@ class PdfTk {
              * @returns {String} Path of the newly created temp file.
              */
             const writeTempFile = srcFile => {
-                const tmpPath = path.join(__dirname, this._tempDir);
+                const tmpPath = this._tempDir;
                 const uniqueId = crypto.randomBytes(16).toString('hex');
-                const tmpFile = `${tmpPath}${uniqueId}.pdf`;
+                const tmpFile = path.normalize(`${tmpPath}/${uniqueId}.pdf`);
                 fs.writeFileSync(tmpFile, srcFile);
                 this.tmpFiles.push(tmpFile);
                 return tmpFile;
@@ -1095,9 +1096,9 @@ module.exports = {
                 writable: true,
             },
             _tempDir: {
-               value: options.tempDir,
-               writable: true,
-           },
+                value: options.tempDir,
+                writable: true,
+            },
         });
     },
 };

--- a/index.js
+++ b/index.js
@@ -42,6 +42,13 @@ class PdfTk {
              */
             this._ignoreWarnings = this._ignoreWarnings || false;
 
+            /**
+             * Allows the plugin to change where the temp file is written.
+             * @member
+             * @type {String}
+             */
+            this._tempDir = this._tempDir || './node-pdftk-tmp/';
+
             const input = [];
 
             /**
@@ -58,7 +65,7 @@ class PdfTk {
              * @returns {String} Path of the newly created temp file.
              */
             const writeTempFile = srcFile => {
-                const tmpPath = path.join(__dirname, './node-pdftk-tmp/');
+                const tmpPath = path.join(__dirname, this._tempDir);
                 const uniqueId = crypto.randomBytes(16).toString('hex');
                 const tmpFile = `${tmpPath}${uniqueId}.pdf`;
                 fs.writeFileSync(tmpFile, srcFile);
@@ -1087,6 +1094,10 @@ module.exports = {
                 value: options.ignoreWarnings,
                 writable: true,
             },
+            _tempDir: {
+               value: options.tempDir,
+               writable: true,
+           },
         });
     },
 };

--- a/test/options.tempDir.spec.js
+++ b/test/options.tempDir.spec.js
@@ -1,0 +1,48 @@
+/* globals describe, it, before, after */
+const chai = require('chai');
+
+const { expect, } = chai;
+
+const pdftk = require('../');
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
+
+describe('option - tempDir', function () {
+
+    const tempDir = path.join(__dirname, 'my-tmp-dir');
+
+    before(function () {
+        fs.mkdirSync(tempDir);
+    });
+
+    after(function () {
+        rimraf(tempDir, function () { });
+    });
+
+    it('should use a custom temp directory', function () {
+
+        pdftk.configure({
+            tempDir,
+        });
+
+        // Need to pass in buffer in order to force temp file to be written
+        const input = fs.readFileSync(path.join(__dirname, './files/form.pdf'));
+
+        return pdftk
+            .input(input)
+            .fillForm({
+                name: 'John Doe',
+                email: 'test@email.com',
+            })
+            .output()
+            .then(buffer => expect(buffer).to.not.be.null)
+            .then(() => {
+                pdftk.configure({
+                    tempDir: path.join(__dirname, '../node-pdftk-tmp/'),
+                });
+            })
+            .catch(err => expect(err).to.be.null);
+    });
+
+});


### PR DESCRIPTION
Love the library, but couldn't be used inside of AWS Lambda, because on the `/tmp` is available for write access. I made it so you can pass in a new temporary directory path and tested it on lambda. Works perfect.

Let me know if something else needs to be done for it, or if you have a better way.